### PR TITLE
Canal Excavator compatibility

### DIFF
--- a/info.json
+++ b/info.json
@@ -16,7 +16,8 @@
     "Cloning-vat-building >= 1.0.4",
     "snouz_better_asteroid_collector >= 1.0.2",
     "snouz_long_electric_gun_turret >= 1.0.5",
-    "snouz_space_platform_hull >= 1.0.1"
+    "snouz_space_platform_hull >= 1.0.1",
+    "? canal-excavator >= 1.12"
   ],
   "space_travel_required": true
 }

--- a/prototypes/compatibility.lua
+++ b/prototypes/compatibility.lua
@@ -195,3 +195,25 @@ if data.raw["technology"]["thinking-brain-technology"] then
     time = 900*500,
   }
 end
+
+if mods["canal-excavator"] then
+  data:extend({{
+    type = "mod-data",
+    name = "canex-panglia-config",
+    data_type = "canex-surface-config",
+    data = {
+      surfaceName = "panglia",
+      localisation = {"space-location-name.panglia"},
+      oreStartingAmount = 10,
+      mining_time = 1,
+      tint = {r = 113, g = 144, b = 125},
+      mineResult = {
+        {type="item", name = "stone", probability = 0.6, amount = 1},
+        {type="item", name = "panglia_panglite", probability = 0.2, amount = 1},
+        {type="item", name = "iron-ore", probability = 0.1, amount = 1},
+        {type="item", name = "copper-ore", probability = 0.1, amount = 1},
+        {type="item", name = "uranium-238", probability = 0.0005, amount = 1},
+      }
+    }
+  }})
+end


### PR DESCRIPTION
Hi,

Some users of my [Canal Excavator](https://mods.factorio.com/mod/canal-excavator) mod asked me to implement compatibility with more planet mods.
Personally I think it's cleaner if the compatibility code is in the planet mod so let me know if you're okay with adding this.

I've created configurations for a whole bunch of mods now, but your planet is a bit of a weird one since there are very few native resources which made it hard to decide what resources my excavator should yield when mining your planet. In the end I took inspiration from the composite rocks and configured it to yield a mix of resources. If you disagree with the yield or think it is too much, you can tweak it as you please.

Let me know what you think.